### PR TITLE
feat(auth): Use tokens in params as headers in API requests

### DIFF
--- a/WebApplication/src/main-landing.js
+++ b/WebApplication/src/main-landing.js
@@ -32,9 +32,8 @@ axios.get('../api/pre-login-configuration').then((config) => {
 
       if (!paramValue) continue;
 
-      localStorage.setItem("vue-token", paramValue);
+      localStorage.setItem(paramName, paramValue);
       orthancApi.updateAuthHeader(paramName);
-      break;    
   }
 
   app.mount('#app-landing')

--- a/WebApplication/src/main-landing.js
+++ b/WebApplication/src/main-landing.js
@@ -30,10 +30,11 @@ axios.get('../api/pre-login-configuration').then((config) => {
   for (let paramName of VALID_TOKEN_PARAMS) {
       const paramValue = params.get(paramName);
 
-      if (!!paramValue) {
-          localStorage.setItem("vue-token", paramValue);
-          orthancApi.updateAuthHeader();
-      }
+      if (!paramValue) continue;
+
+      localStorage.setItem("vue-token", paramValue);
+      orthancApi.updateAuthHeader(paramName);
+      break;    
   }
 
   app.mount('#app-landing')

--- a/WebApplication/src/main-landing.js
+++ b/WebApplication/src/main-landing.js
@@ -10,6 +10,11 @@ import orthancApi from './orthancApi'
 import axios from 'axios'
 
 
+// Names of the params that can contain an authorization token
+// If one of these params contain a token, it will be passed as a header
+// with each request to the Orthanc API
+const VALID_TOKEN_PARAMS = ["token", "auth-token", "authorization"];
+
 
 // before initialization, we must load part of the configuration to know if we need to enable Keycloak or not
 axios.get('../api/pre-login-configuration').then((config) => {
@@ -18,6 +23,18 @@ axios.get('../api/pre-login-configuration').then((config) => {
 
   app.use(store)
   app.use(i18n)
+
+  // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
+  const params = new URLSearchParams(router.currentRoute.value.fullPath);
+
+  for (let paramName of VALID_TOKEN_PARAMS) {
+      const paramValue = params.get(paramName);
+
+      if (!!paramValue) {
+          localStorage.setItem("vue-token", window.keycloak.token);
+          orthancApi.updateAuthHeader();
+      }
+  }
 
   app.mount('#app-landing')
 

--- a/WebApplication/src/main-landing.js
+++ b/WebApplication/src/main-landing.js
@@ -25,9 +25,7 @@ axios.get('../api/pre-login-configuration').then((config) => {
   app.use(i18n)
 
   // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
-  const params = new URLSearchParams(router.currentRoute.value.fullPath);
-
-  console.log("MAIN LANDING", params, router.currentRoute.value);
+  const params = new URLSearchParams(window.location.search);
 
   for (let paramName of VALID_TOKEN_PARAMS) {
       const paramValue = params.get(paramName);

--- a/WebApplication/src/main-landing.js
+++ b/WebApplication/src/main-landing.js
@@ -27,6 +27,8 @@ axios.get('../api/pre-login-configuration').then((config) => {
   // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
   const params = new URLSearchParams(router.currentRoute.value.fullPath);
 
+  console.log("MAIN LANDING", params, router.currentRoute.value);
+
   for (let paramName of VALID_TOKEN_PARAMS) {
       const paramValue = params.get(paramName);
 

--- a/WebApplication/src/main-landing.js
+++ b/WebApplication/src/main-landing.js
@@ -31,7 +31,7 @@ axios.get('../api/pre-login-configuration').then((config) => {
       const paramValue = params.get(paramName);
 
       if (!!paramValue) {
-          localStorage.setItem("vue-token", window.keycloak.token);
+          localStorage.setItem("vue-token", paramValue);
           orthancApi.updateAuthHeader();
       }
   }

--- a/WebApplication/src/main-retrieve-and-view.js
+++ b/WebApplication/src/main-retrieve-and-view.js
@@ -30,10 +30,11 @@ axios.get('../api/pre-login-configuration').then((config) => {
   for (let paramName of VALID_TOKEN_PARAMS) {
       const paramValue = params.get(paramName);
 
-      if (!!paramValue) {
-          localStorage.setItem("vue-token", paramValue);
-          orthancApi.updateAuthHeader();
-      }
+      if (!paramValue) continue;
+
+      localStorage.setItem("vue-token", paramValue);
+      orthancApi.updateAuthHeader(paramName);
+      break;    
   }
 
   app.mount('#app-retrieve-and-view')

--- a/WebApplication/src/main-retrieve-and-view.js
+++ b/WebApplication/src/main-retrieve-and-view.js
@@ -10,6 +10,11 @@ import orthancApi from './orthancApi'
 import axios from 'axios'
 
 
+// Names of the params that can contain an authorization token
+// If one of these params contain a token, it will be passed as a header
+// with each request to the Orthanc API
+const VALID_TOKEN_PARAMS = ["token", "auth-token", "authorization"];
+
 
 // before initialization, we must load part of the configuration to know if we need to enable Keycloak or not
 axios.get('../api/pre-login-configuration').then((config) => {
@@ -18,6 +23,18 @@ axios.get('../api/pre-login-configuration').then((config) => {
 
   app.use(store)
   app.use(i18n)
+
+  // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
+  const params = new URLSearchParams(router.currentRoute.value.fullPath);
+
+  for (let paramName of VALID_TOKEN_PARAMS) {
+      const paramValue = params.get(paramName);
+
+      if (!!paramValue) {
+          localStorage.setItem("vue-token", window.keycloak.token);
+          orthancApi.updateAuthHeader();
+      }
+  }
 
   app.mount('#app-retrieve-and-view')
 

--- a/WebApplication/src/main-retrieve-and-view.js
+++ b/WebApplication/src/main-retrieve-and-view.js
@@ -25,9 +25,7 @@ axios.get('../api/pre-login-configuration').then((config) => {
   app.use(i18n)
 
   // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
-  const params = new URLSearchParams(router.currentRoute.value.fullPath);
-  
-  console.log("MAIN RETRIEVE", params, router.currentRoute.value);
+  const params = new URLSearchParams(window.location.search);
 
   for (let paramName of VALID_TOKEN_PARAMS) {
       const paramValue = params.get(paramName);

--- a/WebApplication/src/main-retrieve-and-view.js
+++ b/WebApplication/src/main-retrieve-and-view.js
@@ -32,9 +32,8 @@ axios.get('../api/pre-login-configuration').then((config) => {
 
       if (!paramValue) continue;
 
-      localStorage.setItem("vue-token", paramValue);
+      localStorage.setItem(paramName, paramValue);
       orthancApi.updateAuthHeader(paramName);
-      break;    
   }
 
   app.mount('#app-retrieve-and-view')

--- a/WebApplication/src/main-retrieve-and-view.js
+++ b/WebApplication/src/main-retrieve-and-view.js
@@ -26,6 +26,8 @@ axios.get('../api/pre-login-configuration').then((config) => {
 
   // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
   const params = new URLSearchParams(router.currentRoute.value.fullPath);
+  
+  console.log("MAIN RETRIEVE", params, router.currentRoute.value);
 
   for (let paramName of VALID_TOKEN_PARAMS) {
       const paramValue = params.get(paramName);

--- a/WebApplication/src/main-retrieve-and-view.js
+++ b/WebApplication/src/main-retrieve-and-view.js
@@ -31,7 +31,7 @@ axios.get('../api/pre-login-configuration').then((config) => {
       const paramValue = params.get(paramName);
 
       if (!!paramValue) {
-          localStorage.setItem("vue-token", window.keycloak.token);
+          localStorage.setItem("vue-token", paramValue);
           orthancApi.updateAuthHeader();
       }
   }

--- a/WebApplication/src/main.js
+++ b/WebApplication/src/main.js
@@ -97,9 +97,7 @@ axios.get('../api/pre-login-configuration').then((config) => {
         });
     } else {
         // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
-        const params = new URLSearchParams(router.currentRoute.value.fullPath);
-
-        console.log("MAIN", params, router.currentRoute.value);
+        const params = new URLSearchParams(window.location.search);
 
         for (let paramName of VALID_TOKEN_PARAMS) {
             const paramValue = params.get(paramName);

--- a/WebApplication/src/main.js
+++ b/WebApplication/src/main.js
@@ -99,6 +99,8 @@ axios.get('../api/pre-login-configuration').then((config) => {
         // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
         const params = new URLSearchParams(router.currentRoute.value.fullPath);
 
+        console.log("MAIN", params, router.currentRoute.value);
+
         for (let paramName of VALID_TOKEN_PARAMS) {
             const paramValue = params.get(paramName);
 

--- a/WebApplication/src/main.js
+++ b/WebApplication/src/main.js
@@ -102,10 +102,11 @@ axios.get('../api/pre-login-configuration').then((config) => {
         for (let paramName of VALID_TOKEN_PARAMS) {
             const paramValue = params.get(paramName);
 
-            if (!!paramValue) {
-                localStorage.setItem("vue-token", paramValue);
-                orthancApi.updateAuthHeader();
-            }
+            if (!paramValue) continue;
+
+            localStorage.setItem("vue-token", paramValue);
+            orthancApi.updateAuthHeader(paramName);
+            break;    
         }
 
         app.mount('#app')

--- a/WebApplication/src/main.js
+++ b/WebApplication/src/main.js
@@ -16,6 +16,10 @@ import Datepicker from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 import mitt from "mitt"
 
+// Names of the params that can contain an authorization token
+// If one of these params contain a token, it will be passed as a header
+// with each request to the Orthanc API
+const VALID_TOKEN_PARAMS = ["token", "auth-token", "authorization"];
 
 // before initialization, we must load part of the configuration to know if we need to enable Keycloak or not
 axios.get('../api/pre-login-configuration').then((config) => {
@@ -92,6 +96,18 @@ axios.get('../api/pre-login-configuration').then((config) => {
             console.log("Could not connect to Keycloak");
         });
     } else {
+        // If there is a param with a token in the params, use it as a header in subsequent calls to the Orthanc API
+        const params = new URLSearchParams(router.currentRoute.value.fullPath);
+
+        for (let paramName of VALID_TOKEN_PARAMS) {
+            const paramValue = params.get(paramName);
+
+            if (!!paramValue) {
+                localStorage.setItem("vue-token", window.keycloak.token);
+                orthancApi.updateAuthHeader();
+            }
+        }
+
         app.mount('#app')
     }
 });

--- a/WebApplication/src/main.js
+++ b/WebApplication/src/main.js
@@ -103,7 +103,7 @@ axios.get('../api/pre-login-configuration').then((config) => {
             const paramValue = params.get(paramName);
 
             if (!!paramValue) {
-                localStorage.setItem("vue-token", window.keycloak.token);
+                localStorage.setItem("vue-token", paramValue);
                 orthancApi.updateAuthHeader();
             }
         }

--- a/WebApplication/src/main.js
+++ b/WebApplication/src/main.js
@@ -104,9 +104,8 @@ axios.get('../api/pre-login-configuration').then((config) => {
 
             if (!paramValue) continue;
 
-            localStorage.setItem("vue-token", paramValue);
+            localStorage.setItem(paramName, paramValue);
             orthancApi.updateAuthHeader(paramName);
-            break;    
         }
 
         app.mount('#app')

--- a/WebApplication/src/orthancApi.js
+++ b/WebApplication/src/orthancApi.js
@@ -4,8 +4,8 @@ import store from "./store"
 import { orthancApiUrl, oe2ApiUrl } from "./globalConfigurations";
 
 export default {
-    updateAuthHeader() {
-        axios.defaults.headers.common['token'] = localStorage.getItem("vue-token")
+    updateAuthHeader(headerKey = "token") {
+        axios.defaults.headers.common[headerKey] = localStorage.getItem("vue-token")
     },
     async loadOe2Configuration() {
         return (await axios.get(oe2ApiUrl + "configuration")).data;

--- a/WebApplication/src/orthancApi.js
+++ b/WebApplication/src/orthancApi.js
@@ -4,8 +4,8 @@ import store from "./store"
 import { orthancApiUrl, oe2ApiUrl } from "./globalConfigurations";
 
 export default {
-    updateAuthHeader(headerKey = "token") {
-        axios.defaults.headers.common[headerKey] = localStorage.getItem("vue-token")
+    updateAuthHeader(headerKey = null) {
+        axios.defaults.headers.common[headerKey ?? "token"] = localStorage.getItem(headerKey ?? "vue-token")
     },
     async loadOe2Configuration() {
         return (await axios.get(oe2ApiUrl + "configuration")).data;


### PR DESCRIPTION
If there is a parameter called 'token', 'auth-token' or 'authorization' in the params of the URL to the explorer, it is extracted and passed as a header to requests to the Orthanc API