### PR TITLE
feat(paths): Redirect /app to /app/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist-ssr
 *.local
 .vscode/
 *~
+build

--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,5 @@ Authors
   1348 Ottignies-Louvain-la-Neuve
   Belgium
   https://uclouvain.be/icteam
+
+* Luc Billaud <luc.billaud.pro@gmail.com>

--- a/WebApplication/index.html
+++ b/WebApplication/index.html
@@ -9,10 +9,11 @@
       // Custom bit of code to redirect to /app/ if the uri is /app
       // The reason for this is that the path to assets is relative
       // so it won't work for /app but it will for /app/
-      const currentUri = window.location.href;
+      const currentUri = new URL(window.location.href);
 
-      if (currentUri.endsWith("app")) {
-        window.location.href = currentUri + "/";
+      if (currentUri.pathname.endsWith("app")) {
+        currentUri.pathname += "/";
+        window.location.href = currentUri.toString();
       }
     </script>
   </head>

--- a/WebApplication/index.html
+++ b/WebApplication/index.html
@@ -5,6 +5,16 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Orthanc Explorer 2</title>
+    <script>
+      // Custom bit of code to redirect to /app/ if the uri is /app
+      // The reason for this is that the path to assets is relative
+      // so it won't work for /app but it will for /app/
+      const currentUri = window.location.href;
+
+      if (currentUri.endsWith("app")) {
+        window.location.href = currentUri + "/";
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
**Features:**

- Added a redirection from /app to /app/ in the index.html file

**Notes:**

 I am working on a plugin and the code is inspired by the code of this repo, so I had the same issue of having the `/app` path (without a trailing slash) not loading correctly its assets. The 2 options I thought about were : serve the assets folder at both the `/app/assets` and `/assets` locations or redirect from `/app` to `/app/`.

I went for the second one and this is the way I found to do it. What do you think of it ? It looks a bit hacky to me, but well... it works ^^ 