### PR TITLE
fix: Study List th colspan

### DIFF
--- a/WebApplication/src/components/StudyList.vue
+++ b/WebApplication/src/components/StudyList.vue
@@ -999,7 +999,7 @@ export default {
         <table class="table table-sm study-table table-borderless">
             <thead class="sticky-top">
                 <tr class="study-column-titles">
-                    <th width="40px" scope="col" ></th>
+                    <th width="40px" scope="col" :colspan="colSpanClearFilter"></th>
                     <th v-if="hasPrimaryViewerIcon" width="2.5rem" scope="col" ></th>
                     <th v-if="hasPdfReportIcon" width="2.5rem" scope="col" ></th>
                     <th v-for="columnTag in uiOptions.StudyListColumns" :key="columnTag" data-bs-toggle="tooltip"


### PR DESCRIPTION
Fixes issue of header and filter rows not aligned properly after latest release.

<img width="1580" height="155" alt="{575B2A57-6656-49CE-A3DB-A3AE449B5A50}" src="https://github.com/user-attachments/assets/52629272-16b9-4361-811e-cee2f8216f2d" />
