### PR TITLE
Add weasis viewer integration

### DIFF
--- a/Plugin/DefaultConfiguration.json
+++ b/Plugin/DefaultConfiguration.json
@@ -105,7 +105,8 @@
                 "meddream": "bi bi-columns-gap",
                 "volview": "bi bi-box",
                 "wsi": "fa-solid fa-microscope fa-button",
-                "stl": "fa-solid fa-cubes"
+                "stl": "fa-solid fa-cubes",
+                "weasis": "bi bi-eye"
             },
             // Defines the order in which the viewer icons should appear in the interface
             // OHIF viewers modes that are not listed here, won't appear in the interface.
@@ -120,7 +121,8 @@
                 "meddream",
                 "volview",
                 "wsi",
-                "stl" // only at instance level
+                "stl", // only at instance level
+                "weasis"
             ],
 
             "MaxStudiesDisplayed": 100,                 // The maximum number of studies displayed in the study list.

--- a/WebApplication/src/components/ResourceButtonGroup.vue
+++ b/WebApplication/src/components/ResourceButtonGroup.vue
@@ -569,6 +569,28 @@ export default {
         isStlViewerButtonEnabled() {
             return this.resourceLevel == 'instance';
         },
+        hasWeasisViewer() {
+            return this.studiesSourceType == SourceType.LOCAL_ORTHANC;
+        },
+        weasisViewerUrl() {
+            if (this.resourceLevel == 'bulk') {
+                const selectedStudiesDicomIds = this.selectedStudies.map(s => s['MainDicomTags']['StudyInstanceUID']);
+                const url = api.getWeasisViewerUrlForBulkStudies(selectedStudiesDicomIds);
+                return url;
+            } else {
+                return api.getWeasisViewerUrl(this.resourceLevel, this.resourceDicomUid);
+            }
+        },
+        hasWeasisViewerButton() {
+            return this.studiesSourceType == SourceType.LOCAL_ORTHANC &&
+                this.hasWeasisViewer && (this.resourceLevel == 'study' || this.resourceLevel == 'bulk');
+        },
+        isWeasisViewerButtonEnabled() {
+            return (this.resourceLevel == 'study' || (this.resourceLevel == 'bulk' && this.selectedStudiesIds.length > 0));
+        },
+        weasisViewerIcon() {
+            return this.getViewerIcon("weasis");
+        },
         hasMedDreamViewer() {
             return this.studiesSourceType == SourceType.LOCAL_ORTHANC && this.uiOptions.EnableOpenInMedDreamViewer;
         },
@@ -882,6 +904,11 @@ export default {
                     :iconClass="stlViewerIcon" :level="computedResourceLevel" :linkUrl="stlViewerUrl"
                     :resourcesOrthancId="resourcesOrthancId" :title="$t('view_in_stl_viewer')"
                     :tokenType="'viewer-instant-link'" :opensInNewTab="true" :smallIcons="smallIcons">
+                </TokenLinkButton>
+                <TokenLinkButton v-if="viewer == 'weasis' && hasWeasisViewerButton"
+                    :disabled="!isWeasisViewerButtonEnabled" :iconClass="weasisViewerIcon"
+                    :level="computedResourceLevel" :linkUrl="weasisViewerUrl" :resourcesOrthancId="resourcesOrthancId"
+                    :title="$t('view_in_weasis')" :tokenType="'viewer-instant-link'" :opensInNewTab="true" :smallIcons="smallIcons">
                 </TokenLinkButton>
             </span>
             <TokenLinkButton v-if="hasInstancePreviewButton" :iconClass="'bi bi-binoculars'" :level="this.resourceLevel"

--- a/WebApplication/src/locales/de.json
+++ b/WebApplication/src/locales/de.json
@@ -208,5 +208,6 @@
     "view_in_osimis": "In OsimisViewer anzeigen",
     "view_in_stone": "In StoneViewer anzeigen",
     "view_in_volview": "In VolView anzeigen",
-    "view_in_wsi_viewer": "In Whole Slide Imaging Viewer anzeigen"
+    "view_in_wsi_viewer": "In Whole Slide Imaging Viewer anzeigen",
+    "view_in_weasis": "In Weasis Viewer anzeigen"
 }

--- a/WebApplication/src/locales/en.json
+++ b/WebApplication/src/locales/en.json
@@ -311,6 +311,7 @@
     "view_in_volview": "View in VolView",
     "view_in_stl_viewer": "View in STL Viewer",
     "view_in_wsi_viewer": "View in Whole Slide Imaging Viewer",
+    "view_in_weasis": "View in Weasis Viewer",
     "worklists" : {
         "copy_tags_from_patient": "Copy",
         "create_button": "Create",

--- a/WebApplication/src/orthancApi.js
+++ b/WebApplication/src/orthancApi.js
@@ -739,6 +739,17 @@ export default {
         // stl/app/o3dv.html
         // stl/app/three.html
     },
+   getWeasisViewerUrl(level, resourceDicomUid) {
+        const parts = ["$dicom:rs", "--url", `"${window.location.origin}/dicom-web"`, "-r", `"studyUID=${resourceDicomUid}"`];
+        const url = "weasis://?" + parts.map(v => encodeURIComponent(v)).join("+");
+        return url
+    },
+    getWeasisViewerUrlForBulkStudies(studiesDicomIds) {
+        const studyUids = studiesDicomIds.join(",");
+        const parts = ["$dicom:rs", "--url", `"${window.location.origin}/dicom-web"`, "-r", `"studyUID=${studyUids}"`];
+        const url = "weasis://?" + parts.map(v => encodeURIComponent(v)).join("+");
+        return url
+    },
     getInstancePreviewUrl(orthancId) {
         return orthancApiUrl + "instances/" + orthancId + "/preview";
     },


### PR DESCRIPTION
This PR adds a button on study level and in bulk mode to be able to open the external application weasis (https://weasis.org) with the study already opened.

See also:
https://weasis.org/en/basics/customize/integration/