### PR TITLE
New Keycloak config param: checkLoginIframe

### DIFF
--- a/Plugin/DefaultConfiguration.json
+++ b/Plugin/DefaultConfiguration.json
@@ -456,7 +456,8 @@
             "Enable": false,
             "Url": "http://change-me:8080/",
             "Realm": "change-me",
-            "ClientId": "change-me"
+            "ClientId": "change-me",
+            "CheckLoginIframe": true
         },
 
         

--- a/WebApplication/src/main.js
+++ b/WebApplication/src/main.js
@@ -69,7 +69,10 @@ axios.get('../api/pre-login-configuration').then((config) => {
 
         window.keycloak = new Keycloak(initOptions);
 
-        window.keycloak.init({ onLoad: initOptions.onLoad }).then(async (auth) => {
+        window.keycloak.init({
+            onLoad: initOptions.onLoad,
+            checkLoginIframe: keycloackConfig['CheckLoginIframe'] || true,
+        }).then(async (auth) => {
 
             if (!auth) {
                 window.location.reload();


### PR DESCRIPTION
This little change makes it possible to turn off the "session status iframe" of keycloak.js. I'll try to sum up what this is and why it is needed. This is **not** AI slop, I typed it in by hand and used my own thoughts.

The "session status iframe" is an optimization mechanism intended to save network bandwidth. It is a mechanism that keycloak.js uses to detect a logout event on any of the apps that are under the same SSO. When it is turned on, keycloak.js embeds an iframe into the UI that loads the URL `{keycloak-base-url}/realms/dev/protocol/openid-connect/login-status-iframe.html`. As soon as the user logs out from its SSO session in any app, the cookies for that domain become invalid, so the cookies inside that iframe become invalid and keycloak.js can detect this without using the network at all.

If the host domain of our Keycloak instance is different from the domain of the app that is using keycloak.js, then the iframe is considered "3rd-party context" and the cookies inside it become unreachable to the embedding browser window, thus the session status mechanism can't work. What happens in this case is keycloak.js continually refreshes the whole UI every 5 seconds making it unusable.

In our first iteration of introducing Keycloak-based SSO, we solved this by "hiding" our keycloak instance behind a proxy using a different URL path under the same domain, like so: `{customer-base-url}/keycloak` but some members of our team pointed out that this is not the best security practice because the real identity of the authorization server becomes hidden which could lead to subtle issues.
We'd like to use the actual, real domain name of our Keycloak instance but that means using a different domain, which leads to a broken session status iframe.

This iframe thing is a somewhat dated practice and is becoming less and less usable as recent 3rd-party context policies of browsers forbid access to cookies in embedded iframes. It will eventually become unusable (if not already) so it is encouraged to solve this "single log out" / session tracking problem in other ways and turn this feature off.

This change makes it possible to turn it off on the orthanc config json level.

Relevant Keycloak docs: https://www.keycloak.org/securing-apps/javascript-adapter#_session_status_iframe

I'm currently trying to build the OE2 plugin with these changes and use it with the latest orthancteam/orthanc docker image but I'm not too experienced in C++ builds and I'm running into mismatch `.so` versions (on my host where I build vs. in the orthancteam/orthanc container).

Please, if you accept this change, do a release and create a new build of the OE2 plugin soon!
Thank you!